### PR TITLE
Low Bandwidth: Passing low_bandwidth param if in options.

### DIFF
--- a/lib/passport-familysearch/strategy.js
+++ b/lib/passport-familysearch/strategy.js
@@ -78,6 +78,10 @@ Strategy.prototype.authorizationParams = function (options) {
     this._oauth2._clientSecret = '';
   }
 
+  if(options.lowBandwidth){
+    params.low_bandwidth = true;
+  }
+  
   return params;
 };
 


### PR DESCRIPTION
### Feature

Adding support to pass a `lowBandwidth` option in authentication.
